### PR TITLE
Prefix email address with `mailto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - I sometimes teach computer science and programming
 - I love terminals and all things CLI. DWM + Alacritty + Tmux + Neovim.
 - My gpg key ID: 66DB3FBACBDD05CC
-- Yes, in fact, I am currently incarcerated (I have a [blog post](https://pthorpe92.dev/intro/my-story) on my story.
+- Yes, in fact, I am currently incarcerated (I have a [blog post](https://pthorpe92.dev/intro/my-story) on my story).
 - Advocate for Maine's education based reform approach
 - I want to help bring technology and education to prisons across the country
 - I am scheduled for release in ~May 2025

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ I love to collab on projects, working on [eza](https://github.com/eza-community/
 
 You can find me on [LinkedIn](https://linkedin.com/in/PThorpe92)
 
-or send me an [email](preston@pthorpe92.dev)
+or send me an [email](mailto:preston@pthorpe92.dev)


### PR DESCRIPTION
Add a `mailto` link to the email address so it automatically opens the mail client instead of leading to github 404 page.

